### PR TITLE
Use Geofabrick for raw OSM data

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ cd openmaptiles
 mkdir -p data
 
 echo "====> : Downloading Singapore Metro Extract"
-curl https://s3.amazonaws.com/metro-extracts.mapzen.com/singapore.osm.pbf -o data/singapore.osm.pbf
+curl https://download.geofabrik.de/asia/malaysia-singapore-brunei-latest.osm.pbf -o data/singapore.osm.pbf
 
 cp ../.env .env
 cp ../docker-compose-config.yml data/docker-compose-config.yml


### PR DESCRIPTION
This is because of Mapzen's shutdown which ended Metro Extracts data service